### PR TITLE
Ensure subcontractor_type is passed to creation of new work

### DIFF
--- a/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py
+++ b/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py
@@ -66,6 +66,7 @@ class SubcontractorTimesheetInvoice(models.TransientModel):
         vals.update({
             'sale_price_unit': record.sale_price_unit,
             'cost_price_unit': record.cost_price_unit,
+            'subcontractor_type': record.subcontractor_type,
             })
         return vals
 


### PR DESCRIPTION
Before:
1) Create a task, invoice it to a invoice.
2) in subcontractor works view, you will see no subcontractor type

After:
2) in subcontractor works view, you will see the correct subcontractor type


Ping @sebastienbeau @bguillot 