### PR TITLE
Write unicode on invoice line name

### DIFF
--- a/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py
+++ b/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py
@@ -85,7 +85,7 @@ class SubcontractorTimesheetInvoice(models.TransientModel):
             "task_id": task_id,
             "invoice_id": self.invoice_id.id,
             "product_id": product.id,
-            "name": "[{}] {}".format(task.id, task.name),
+            "name": u"[{}] {}".format(task.id, task.name),
             "subcontracted": True,
             "uom_id": task.project_id.uom_id.id,
         }


### PR DESCRIPTION
I met an error when invoicing timesheet liked to task containing accent.
I already had this some time ago and had juste renamed the tasks.

Here the stack trace : 

  File "/odoo/external-src/subcontractor/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py", line 140, in action_invoice
    self._add_update_invoice_line(task_id, data)
  File "/odoo/external-src/subcontractor/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py", line 105, in _add_update_invoice_line
    line_vals = self._prepare_invoice_line(task_id, data)
  File "/odoo/external-src/subcontractor/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py", line 88, in _prepare_invoice_line
    "name": "[{}] {}".format(task.id, task.name),
UnicodeEncodeError: 'ascii' codec can't encode characters in position 9-10: ordinal not in range(128)


@bguillot @sebastienbeau @chafique-delli @bealdav @mourad-ehm 