### PR TITLE
[FIX] when invoicing timesheet updating an existing invoice, automati…

### DIFF
--- a/project_invoicing_subcontractor/models/account_move.py
+++ b/project_invoicing_subcontractor/models/account_move.py
@@ -610,3 +610,28 @@ class AccountMove(models.Model):
                 "paid",
             ):
                 invoice.to_pay = True
+
+    def _is_invoiced_with_parent_task_option(self):
+        """
+        Res is True if invoice has been invoiced with parent task option
+               False if invoice has been invoiced without parent task option
+               None if it was not applicable. (no child task in the invoice)
+        """
+        self.ensure_one()
+        res = None
+        # check if invoice parent task was used during invoicing
+        has_child_task = False
+        for inv_line in self.invoice_line_ids:
+            timesheet_tasks = inv_line.subcontractor_work_ids.timesheet_line_ids.task_id
+            if not timesheet_tasks:
+                continue
+            if not has_child_task and inv_line.task_id.parent_id:
+                has_child_task = True
+            if len(timesheet_tasks) > 1 or (
+                len(timesheet_tasks) == 1 and timesheet_tasks.id != inv_line.task_id
+            ):
+                res = True
+                break
+        if not res and has_child_task:
+            res = False
+        return res

--- a/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice_view.xml
+++ b/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice_view.xml
@@ -23,7 +23,7 @@
                 <field name='has_parent_task' invisible="1" />
                 <field
                         name="invoice_parent_task"
-                        attrs="{'invisible': [('has_parent_task', '=', False)]}"
+                        attrs="{'invisible': [('has_parent_task', '=', False)], 'readonly': [('invoice_id', '!=', False)]}"
                     />
 
                 <field name="to_invoice_partner_id" invisible="1" />


### PR DESCRIPTION
…cally compute the invoice parent task option, for consistency

When updating an invoice, the current implementation delete the existing line and re-create it from all timesheet lines.
The invoice parent task option must be consistent.

2 cases fixed : 
1) I have an invoice with a line linked to a parent task and linked subtasks timesheet lines but linked to the parent task, because invoice_parent_task was set on invoice creation..
I try to update the invoice with a timesheet linked to the parent task but without the invoice parent task option (it is actually hidden at this stage...) => Odoo will fail because it updates the main dict with the dedicated  subtask instead of grouping by parent task.

2)  I have an invoice with a line linked to a parent task and linked subtasks timesheet lines but linked to the parent task, because invoice_parent_task was set on invoice creation..
I try to update the invoice with a timesheet linked to a subtask => I forget to check the invoice parent task option => Odoo will succeed but will create a dedicated line for the subtask while other timesheet of the same task have already been invoiced on another line...

@sebastienbeau @bguillot 