### PR TITLE
[FIX] Only check invoicing mode is the same for all invoice lines for…

### DIFF
--- a/project_invoicing_subcontractor/models/account_move.py
+++ b/project_invoicing_subcontractor/models/account_move.py
@@ -400,13 +400,14 @@ class AccountMove(models.Model):
                     "same partner"
                 )
             )
-        modes = self.invoice_line_ids.analytic_account_id.project_ids.mapped(
-            "invoicing_mode"
-        )
-        if modes and not all(x == modes[0] for x in modes):
-            raise exceptions.ValidationError(
-                _("All invoice lines should have the same invoicing mode.")
+        if self.move_type in ("in_invoice", "in_refund"):
+            modes = self.invoice_line_ids.analytic_account_id.project_ids.mapped(
+                "invoicing_mode"
             )
+            if modes and not all(x == modes[0] for x in modes):
+                raise exceptions.ValidationError(
+                    _("All invoice lines should have the same invoicing mode.")
+                )
 
     def _post(self, soft=True):
         for move in self:


### PR DESCRIPTION
… supplier invoices

I do believe it is not an issue to have multiples mode un customer invoices and it is a possible case, mainly with contract, invoicing both infra and maintenance/migration stuff Not sure it is a real issue for supplier invoice but it should not happen, so keep it for safety