### PR TITLE
[IMP] For subcontractor total qty on invoice line

### DIFF
--- a/project_invoicing_subcontractor/models/account_move_line.py
+++ b/project_invoicing_subcontractor/models/account_move_line.py
@@ -81,7 +81,7 @@ class AccountMoveLine(models.Model):
                     record.product_uom_id
                 )
             )
-            if abs(record.timesheet_qty - record.quantity) > 0.001:
+            if abs(record.timesheet_qty - record.quantity) > 0.002:
                 record.timesheet_error = "⏰ %s" % record.timesheet_qty
 
     @api.depends(

--- a/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py
+++ b/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py
@@ -365,12 +365,22 @@ class SubcontractorTimesheetInvoice(models.TransientModel):
         line_vals = self._prepare_invoice_line(invoice, task, timesheet_lines)
         # add subcontractors vals
         subcontractor_vals = []
+        total_subcontractor_quantity = 0.0
         for employee_id, line_ids in task_data.items():
             val = self._prepare_subcontractor_work(employee_id, line_ids)
             subcontractor_vals.append((0, 0, val))
+            total_subcontractor_quantity += val["quantity"]
         if subcontractor_vals:
             line_vals["subcontractor_work_ids"] = subcontractor_vals
             line_vals["subcontracted"] = True
+            # To avoid rounding issues between invoice qty and subcontractor line
+            # quantities, we set the sum of subcontract on invoice line.
+            # As a security, we still check the difference is small...
+            if (
+                abs(line_vals.get("quantity", 0.0) - total_subcontractor_quantity)
+                < 0.005
+            ):
+                line_vals["quantity"] = total_subcontractor_quantity
 
         if not inv_line:
             invoice_line_vals_list = [(0, 0, line_vals)]


### PR DESCRIPTION
To avoid quantity difference between invoice line and subcontractor, we copy the quantity from subcontractor to invoice line (if diff is really small), this way, we avoid amount differences between the invoice line and the subcontractor. On the other hand, we loose a bit of accurency between invoice line and timesheet line.