### PR TITLE
[FIX] Avoid start/end dates on prepaid supplier invoice

### DIFF
--- a/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py
+++ b/project_invoicing_subcontractor/wizards/subcontractor_timesheet_invoice.py
@@ -290,8 +290,17 @@ class SubcontractorTimesheetInvoice(models.TransientModel):
             "quantity": quantity,
             "project_id": project.id,
         }
-        if hasattr(self.env["account.move.line"], "start_date") and hasattr(
-            self.env["account.move.line"], "end_date"
+        # we do not add start/end date on prepaid invoices because it won't be
+        # propagated to the prepaid misc move and it would create inconsistencies
+        # for the cut-off.
+        # We we wanted to propagate it, we would need to stop grouping the invoice
+        # lines in the prepaid misc move + find a way to be sure to take the misc
+        # journal when generating the cut-off (which take only sales journals
+        # by default
+        if (
+            project.invoicing_typology_id.invoicing_mode != "customer_prepaid"
+            and hasattr(self.env["account.move.line"], "start_date")
+            and hasattr(self.env["account.move.line"], "end_date")
         ):
             start_date = min(timesheet_lines.mapped("date"))
             end_date = max(timesheet_lines.mapped("date"))


### PR DESCRIPTION
These dates are difficult to propagate to the prepaid misc move, because we should stop grouping the line + the misc move is not taken into account by default in the cut-off